### PR TITLE
Support multi-file analysis and session merging

### DIFF
--- a/src/SecuNik.API/Controllers/AnalysisController.cs
+++ b/src/SecuNik.API/Controllers/AnalysisController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using SecuNik.Core.Interfaces;
 using SecuNik.Core.Models;
 using SecuNik.Core.Exceptions;
+using SecuNik.Core.Services;
 using System;
 using System.IO;
 using System.Threading.Tasks;
@@ -18,6 +19,7 @@ namespace SecuNik.API.Controllers
         private readonly IAnalysisEngine _analysisEngine;
         private readonly ILogger<AnalysisController> _logger;
         private readonly string _uploadPath;
+        private static readonly Dictionary<string, AnalysisResult> _sessions = new();
 
         public AnalysisController(IAnalysisEngine analysisEngine, ILogger<AnalysisController> logger, IConfiguration configuration)
         {
@@ -147,6 +149,107 @@ namespace SecuNik.API.Controllers
                     {
                         _logger.LogWarning(ex, "Failed to delete temporary file: {TempFilePath}", tempFilePath);
                     }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Upload multiple files and analyze them together
+        /// </summary>
+        [HttpPost("upload-multiple")]
+        [ProducesResponseType(typeof(AnalysisResult), 200)]
+        [ProducesResponseType(typeof(ErrorResponse), 400)]
+        [ProducesResponseType(typeof(ErrorResponse), 500)]
+        public async Task<ActionResult<AnalysisResult>> UploadMultiple([FromForm] IFormFileCollection files, [FromForm] string? sessionId = null, [FromForm] AnalysisOptionsDto? options = null)
+        {
+            if (files == null || files.Count == 0)
+                return BadRequest(new ErrorResponse("No files uploaded"));
+
+            var analysisId = sessionId ?? Guid.NewGuid().ToString();
+            var tempFiles = new List<string>();
+            var requests = new List<AnalysisRequest>();
+
+            try
+            {
+                foreach (var file in files)
+                {
+                    if (file.Length == 0) continue;
+
+                    var ext = Path.GetExtension(file.FileName);
+                    var tempName = $"secunik_{Guid.NewGuid()}{ext}";
+                    var tempPath = Path.Combine(_uploadPath, tempName);
+                    using (var stream = new FileStream(tempPath, FileMode.Create))
+                        await file.CopyToAsync(stream);
+                    tempFiles.Add(tempPath);
+
+                    if (!await _analysisEngine.CanProcessFileAsync(tempPath))
+                    {
+                        Cleanup(tempFiles);
+                        var supported = await _analysisEngine.GetSupportedFileTypesAsync();
+                        return BadRequest(new ErrorResponse($"Unsupported file type '{ext}'. Supported types: {string.Join(", ", supported)}"));
+                    }
+
+                    requests.Add(new AnalysisRequest
+                    {
+                        FilePath = tempPath,
+                        OriginalFileName = file.FileName,
+                        Options = new AnalysisOptions
+                        {
+                            EnableAIAnalysis = options?.EnableAIAnalysis ?? true,
+                            GenerateExecutiveReport = options?.GenerateExecutiveReport ?? true,
+                            IncludeTimeline = options?.IncludeTimeline ?? true,
+                            MaxSecurityEvents = options?.MaxSecurityEvents ?? 10000,
+                            FocusKeywords = options?.FocusKeywords ?? new List<string>()
+                        }
+                    });
+                }
+
+                var result = await _analysisEngine.AnalyzeFilesAsync(requests);
+
+                if (!string.IsNullOrWhiteSpace(sessionId))
+                {
+                    if (_sessions.ContainsKey(sessionId))
+                    {
+                        _sessions[sessionId] = AnalysisEngine.MergeResults(new[] { _sessions[sessionId], result });
+                    }
+                    else
+                    {
+                        _sessions[sessionId] = result;
+                    }
+                    result = _sessions[sessionId];
+                }
+
+                return Ok(new
+                {
+                    success = true,
+                    analysisId = analysisId,
+                    timestamp = DateTime.UtcNow,
+                    result
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error during multi-file upload");
+                return StatusCode(500, new ErrorResponse($"Failed to analyze files: {ex.Message}"));
+            }
+            finally
+            {
+                Cleanup(tempFiles);
+            }
+        }
+
+        private void Cleanup(IEnumerable<string> files)
+        {
+            foreach (var path in files)
+            {
+                try
+                {
+                    if (System.IO.File.Exists(path))
+                        System.IO.File.Delete(path);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to delete temporary file: {TempFilePath}", path);
                 }
             }
         }

--- a/src/SecuNik.Core/Interfaces/IAnalysisEngine.cs
+++ b/src/SecuNik.Core/Interfaces/IAnalysisEngine.cs
@@ -7,6 +7,7 @@ namespace SecuNik.Core.Interfaces
     public interface IAnalysisEngine
     {
         Task<AnalysisResult> AnalyzeFileAsync(AnalysisRequest request);
+        Task<AnalysisResult> AnalyzeFilesAsync(IEnumerable<AnalysisRequest> files);
         Task<List<string>> GetSupportedFileTypesAsync();
         Task<bool> CanProcessFileAsync(string filePath);
     }

--- a/tests/SecuNik.API.Tests/MultiUploadTests.cs
+++ b/tests/SecuNik.API.Tests/MultiUploadTests.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using SecuNik.API.Controllers;
+using SecuNik.Core.Interfaces;
+using SecuNik.Core.Models;
+using Xunit;
+
+public class MultiUploadTests
+{
+    [Fact]
+    public async Task UploadMultiple_CallsEngine()
+    {
+        var mockEngine = new Mock<IAnalysisEngine>();
+        mockEngine.Setup(e => e.CanProcessFileAsync(It.IsAny<string>())).ReturnsAsync(true);
+        mockEngine.Setup(e => e.AnalyzeFilesAsync(It.IsAny<IEnumerable<AnalysisRequest>>()))
+            .ReturnsAsync(new AnalysisResult { Technical = new TechnicalFindings() });
+        mockEngine.Setup(e => e.GetSupportedFileTypesAsync()).ReturnsAsync(new List<string> { ".log" });
+
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string,string>()).Build();
+        var controller = new AnalysisController(mockEngine.Object, new NullLogger<AnalysisController>(), config);
+
+        var ms = new MemoryStream(Encoding.UTF8.GetBytes("test"));
+        var file = new FormFile(ms, 0, ms.Length, "file", "test.log");
+        var files = new FormFileCollection { file, file };
+
+        var result = await controller.UploadMultiple(files, null, new AnalysisOptionsDto());
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        mockEngine.Verify(e => e.AnalyzeFilesAsync(It.IsAny<IEnumerable<AnalysisRequest>>()), Times.Once());
+    }
+}

--- a/tests/SecuNik.API.Tests/SecuNik.API.Tests.csproj
+++ b/tests/SecuNik.API.Tests/SecuNik.API.Tests.csproj
@@ -12,6 +12,8 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="FluentAssertions" Version="8.3.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>

--- a/tests/SecuNik.Core.Tests/MultiFileAnalysisTests.cs
+++ b/tests/SecuNik.Core.Tests/MultiFileAnalysisTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using SecuNik.Core.Interfaces;
+using SecuNik.Core.Models;
+using SecuNik.Core.Services;
+using Xunit;
+
+public class MultiFileAnalysisTests
+{
+    private class FakeAI : IAIAnalysisService
+    {
+        public Task<bool> IsAvailableAsync() => Task.FromResult(true);
+        public Task<AIInsights> GenerateInsightsAsync(TechnicalFindings findings)
+        {
+            return Task.FromResult(new AIInsights
+            {
+                SeverityScore = findings.SecurityEvents.Count
+            });
+        }
+        public Task<ExecutiveReport> GenerateExecutiveReportAsync(TechnicalFindings f, AIInsights i)
+        {
+            return Task.FromResult(new ExecutiveReport { Summary = "ok" });
+        }
+    }
+
+    [Fact]
+    public void MergeResults_CombinesEvents()
+    {
+        var r1 = new AnalysisResult
+        {
+            Technical = new TechnicalFindings { SecurityEvents = new List<SecurityEvent> { new SecurityEvent() } },
+            AI = new AIInsights { SeverityScore = 3 }
+        };
+        var r2 = new AnalysisResult
+        {
+            Technical = new TechnicalFindings { SecurityEvents = new List<SecurityEvent> { new SecurityEvent() } },
+            AI = new AIInsights { SeverityScore = 5 }
+        };
+
+        var merged = AnalysisEngine.MergeResults(new[] { r1, r2 });
+        merged.Technical.SecurityEvents.Count.Should().Be(2);
+        merged.AI.SeverityScore.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task AnalyzeFilesAsync_ReturnsMergedResult()
+    {
+        var temp1 = Path.GetTempFileName() + ".syslog";
+        var temp2 = Path.GetTempFileName() + ".syslog";
+        await File.WriteAllTextAsync(temp1, "Jan 10 12:00:00 host sshd: login ok\n");
+        await File.WriteAllTextAsync(temp2, "Jan 11 13:00:00 host sshd: login ok\n");
+
+        var parsers = new List<IUniversalParser>
+        {
+            new SyslogParser(new NullLogger<SyslogParser>())
+        };
+        var parserService = new UniversalParserService(parsers, new NullLogger<UniversalParserService>());
+        var engine = new AnalysisEngine(parserService, new FakeAI(), new NullLogger<AnalysisEngine>());
+
+        var requests = new[]
+        {
+            new AnalysisRequest { FilePath = temp1, Options = new AnalysisOptions { EnableAIAnalysis = false, GenerateExecutiveReport = false, IncludeTimeline = false } },
+            new AnalysisRequest { FilePath = temp2, Options = new AnalysisOptions { EnableAIAnalysis = false, GenerateExecutiveReport = false, IncludeTimeline = false } }
+        };
+
+        var result = await engine.AnalyzeFilesAsync(requests);
+        result.Technical.SecurityEvents.Count.Should().Be(2);
+
+        File.Delete(temp1);
+        File.Delete(temp2);
+    }
+}


### PR DESCRIPTION
## Summary
- extend `IAnalysisEngine` with `AnalyzeFilesAsync`
- handle multiple files in `AnalysisEngine` and merge results via new `MergeResults`
- expose multi-file upload endpoint and session tracking in `AnalysisController`
- add unit tests for merging and controller

## Testing
- `dotnet test ../tests/SecuNik.Core.Tests/SecuNik.Core.Tests.csproj`
- `dotnet test ../tests/SecuNik.API.Tests/SecuNik.API.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68482f9e24888323818a4e6e734c3b39