### PR TITLE
Increase upload limit to 200MB

### DIFF
--- a/src/SecuNik.API/Controllers/AnalysisController.cs
+++ b/src/SecuNik.API/Controllers/AnalysisController.cs
@@ -45,8 +45,8 @@ namespace SecuNik.API.Controllers
                 return BadRequest(new ErrorResponse("No file uploaded or file is empty"));
             }
 
-            // Validate file size (50MB limit for Phase 1)
-            const long maxFileSize = 50 * 1024 * 1024; // 50MB
+            // Validate file size (200MB limit)
+            const long maxFileSize = 200 * 1024 * 1024; // 200MB
             if (file.Length > maxFileSize)
             {
                 return BadRequest(new ErrorResponse($"File size exceeds maximum limit of {maxFileSize / (1024 * 1024)}MB"));
@@ -310,7 +310,7 @@ namespace SecuNik.API.Controllers
                 {
                     supportedTypes = supportedTypes,
                     description = "File extensions supported by SecuNik analysis engine",
-                    maxFileSize = "50MB"
+                    maxFileSize = "200MB"
                 });
             }
             catch (Exception ex)

--- a/src/SecuNik.API/Program.cs
+++ b/src/SecuNik.API/Program.cs
@@ -47,7 +47,7 @@ namespace SecuNik.API
             // Configure file upload
             builder.Services.Configure<Microsoft.AspNetCore.Http.Features.FormOptions>(options =>
             {
-                options.MultipartBodyLengthLimit = 50 * 1024 * 1024; // 50MB
+                options.MultipartBodyLengthLimit = 200 * 1024 * 1024; // 200MB
             });
 
             var app = builder.Build();

--- a/src/SecuNik.API/wwwroot/index.html
+++ b/src/SecuNik.API/wwwroot/index.html
@@ -131,7 +131,7 @@
                         <div class="upload-icon">📤</div>
                         <div class="upload-text">Drop Evidence Files Here</div>
                         <div class="upload-subtext">Supports CSV, JSON, LOG, TXT, EVTX, EVT, WTMP, UTMP, BTMP, LASTLOG,
-                            PCAP/PCAPNG, SYSLOG, FWLOG, DBLOG, MAILLOG, and DNSLOG files up to 50MB</div>
+                            PCAP/PCAPNG, SYSLOG, FWLOG, DBLOG, MAILLOG, and DNSLOG files up to 200MB</div>
                         <div class="upload-actions">
                             <button class="btn primary" id="chooseFilesBtn">
                                 <span>📁</span>

--- a/src/SecuNik.API/wwwroot/js/app.js
+++ b/src/SecuNik.API/wwwroot/js/app.js
@@ -278,9 +278,9 @@ class SecuNikApp {
     }
 
     validateFile(file) {
-        const maxSize = 50 * 1024 * 1024;
+        const maxSize = 200 * 1024 * 1024;
         if (file.size > maxSize) {
-            this.showNotification('File too large. Maximum size is 50MB.', 'error');
+            this.showNotification('File too large. Maximum size is 200MB.', 'error');
             return false;
         }
 


### PR DESCRIPTION
## Summary
- bump maximum upload size in `AnalysisController` to 200MB
- return `"200MB"` from supported types endpoint
- allow 200MB uploads in API configuration
- update client validation and messages for 200MB
- update upload zone text in homepage
- confirm parser-level validation allows files up to at least 1GB

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848324206a0832386eb40437f2d7ddd