### PR TITLE
Add .NET SDK check for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ dotnet build
 
 This builds the solution defined in `src/SecuNik.sln`.
 
+## Running Tests
+
+The tests require the [.NET SDK 8](https://dotnet.microsoft.com/download).
+After installing the SDK, execute:
+
+```bash
+dotnet test
+```
+
+You can also run `npm test` which calls the same command and checks that the SDK is available.
+
 ## Running the API
 
 Run the API project directly using `dotnet run`:

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "dotnet build src/SecuNik.sln",
     "dev": "dotnet run --project src/SecuNik.API",
+    "pretest": "node scripts/check-dotnet.js",
     "test": "dotnet test",
     "clean": "dotnet clean src/SecuNik.sln"
   },

--- a/scripts/check-dotnet.js
+++ b/scripts/check-dotnet.js
@@ -1,0 +1,8 @@
+const { execSync } = require('child_process');
+
+try {
+  execSync('dotnet --version', { stdio: 'inherit' });
+} catch (err) {
+  console.error('The .NET SDK is required but was not found. Install it from https://dotnet.microsoft.com/download.');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- document the need for the .NET SDK before running tests
- add a pretest script that verifies the `dotnet` CLI exists

## Testing
- `npm test` *(fails: .NET SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ca6cc3348323a77446fa52d593c1