### PR TITLE
Inject HttpClient via DI

### DIFF
--- a/src/SecuNik.AI/Configuration/ServiceCollectionExtensions.cs
+++ b/src/SecuNik.AI/Configuration/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Net.Http;
 using SecuNik.Core.Interfaces;
 using SecuNik.AI.Services;
 
@@ -11,6 +12,18 @@ namespace SecuNik.AI.Configuration
     {
         public static IServiceCollection AddSecuNikAI(this IServiceCollection services)
         {
+            services.AddHttpClient("OpenAI", (provider, client) =>
+            {
+                var configuration = provider.GetRequiredService<IConfiguration>();
+                var apiKey = configuration["OpenAI:ApiKey"];
+                client.BaseAddress = new Uri("https://api.openai.com/v1/");
+                if (!string.IsNullOrEmpty(apiKey))
+                {
+                    client.DefaultRequestHeaders.Add("Authorization", $"Bearer {apiKey}");
+                }
+                client.DefaultRequestHeaders.Add("User-Agent", "SecuNIK-CyberSecurity-Platform/1.0");
+            });
+
             // Register the AI analysis service
             services.AddScoped<IAIAnalysisService>(provider =>
             {
@@ -33,7 +46,9 @@ namespace SecuNik.AI.Configuration
                         var temperature = float.TryParse(temperatureStr, out var temp) ? temp : 0.3f;
 
                         // Try to create OpenAI service
-                        return new OpenAIIntelligenceService(apiKey, model, maxTokens, temperature);
+                        var httpClientFactory = provider.GetRequiredService<IHttpClientFactory>();
+                        var httpClient = httpClientFactory.CreateClient("OpenAI");
+                        return new OpenAIIntelligenceService(httpClient, apiKey, model, maxTokens, temperature);
                     }
                     catch (Exception)
                     {

--- a/src/SecuNik.AI/SecuNik.AI.csproj
+++ b/src/SecuNik.AI/SecuNik.AI.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/src/SecuNik.AI/Services/OpenAIIntelligenceService.cs
+++ b/src/SecuNik.AI/Services/OpenAIIntelligenceService.cs
@@ -22,17 +22,18 @@ namespace SecuNik.AI.Services
         private readonly string _apiKey;
 
         public OpenAIIntelligenceService(
+            HttpClient httpClient,
             string apiKey,
             string model = "gpt-4o-mini",
             int maxTokens = 2000,
             float temperature = 0.3f)
         {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
             _apiKey = apiKey ?? throw new ArgumentNullException(nameof(apiKey));
             _model = model;
             _maxTokens = maxTokens;
             _temperature = temperature;
 
-            _httpClient = new HttpClient();
             _httpClient.BaseAddress = new Uri("https://api.openai.com/v1/");
             _httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {_apiKey}");
             _httpClient.DefaultRequestHeaders.Add("User-Agent", "SecuNIK-CyberSecurity-Platform/1.0");
@@ -368,9 +369,5 @@ Requirements:
             return null;
         }
 
-        public void Dispose()
-        {
-            _httpClient?.Dispose();
-        }
     }
 }

--- a/tests/SecuNik.API.Tests/MultiUploadTests.cs
+++ b/tests/SecuNik.API.Tests/MultiUploadTests.cs
@@ -33,7 +33,7 @@ public class MultiUploadTests
 
         var result = await controller.UploadMultiple(files, null, new AnalysisOptionsDto());
 
-        result.Result.Should().BeOfType<OkObjectResult>();
+        result.Should().BeOfType<OkObjectResult>();
         mockEngine.Verify(e => e.AnalyzeFilesAsync(It.IsAny<IEnumerable<AnalysisRequest>>()), Times.Once());
     }
 }


### PR DESCRIPTION
## Summary
- register HttpClient using AddHttpClient
- inject HttpClient into OpenAIIntelligenceService
- provide DI registered HttpClient when building the service
- fix API tests for updated return type

## Testing
- `dotnet test tests/SecuNik.API.Tests/SecuNik.API.Tests.csproj -v minimal`
- `dotnet test tests/SecuNik.AI.Tests/SecuNik.AI.Tests.csproj -v minimal`
- `dotnet test tests/SecuNik.Core.Tests/SecuNik.Core.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6849293dce488323a19d534297e71009