### PR TITLE
Remove FluentAssertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ dotnet test
 
 You can also run `npm test` which calls the same command and checks that the SDK is available.
 
+The test projects rely solely on xUnit's built-in `Assert` methods. Earlier versions used the
+FluentAssertions library, but it now requires a commercial license. Switching to xUnit
+assertions keeps the repository fully MIT licensed without additional restrictions.
+
 ## Running the API
 
 Run the API project directly using `dotnet run`:

--- a/tests/SecuNik.API.Tests/MultiUploadTests.cs
+++ b/tests/SecuNik.API.Tests/MultiUploadTests.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
-using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
@@ -33,7 +32,7 @@ public class MultiUploadTests
 
         var result = await controller.UploadMultiple(files, null, new AnalysisOptionsDto());
 
-        result.Should().BeOfType<OkObjectResult>();
+        Assert.IsType<OkObjectResult>(result);
         mockEngine.Verify(e => e.AnalyzeFilesAsync(It.IsAny<IEnumerable<AnalysisRequest>>()), Times.Once());
     }
 }

--- a/tests/SecuNik.API.Tests/SecuNik.API.Tests.csproj
+++ b/tests/SecuNik.API.Tests/SecuNik.API.Tests.csproj
@@ -12,7 +12,6 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="FluentAssertions" Version="8.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />

--- a/tests/SecuNik.Core.Tests/MultiFileAnalysisTests.cs
+++ b/tests/SecuNik.Core.Tests/MultiFileAnalysisTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using SecuNik.Core.Interfaces;
 using SecuNik.Core.Models;
@@ -42,8 +41,8 @@ public class MultiFileAnalysisTests
         };
 
         var merged = AnalysisEngine.MergeResults(new[] { r1, r2 });
-        merged.Technical.SecurityEvents.Count.Should().Be(2);
-        merged.AI.SeverityScore.Should().Be(5);
+        Assert.Equal(2, merged.Technical.SecurityEvents.Count);
+        Assert.Equal(5, merged.AI.SeverityScore);
     }
 
     [Fact]
@@ -68,7 +67,7 @@ public class MultiFileAnalysisTests
         };
 
         var result = await engine.AnalyzeFilesAsync(requests);
-        result.Technical.SecurityEvents.Count.Should().Be(2);
+        Assert.Equal(2, result.Technical.SecurityEvents.Count);
 
         File.Delete(temp1);
         File.Delete(temp2);

--- a/tests/SecuNik.Core.Tests/NormalizationAndCorrelationTests.cs
+++ b/tests/SecuNik.Core.Tests/NormalizationAndCorrelationTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using FluentAssertions;
 using SecuNik.Core.Models;
 using SecuNik.Core.Services;
 using Xunit;
@@ -17,9 +16,9 @@ public class NormalizationAndCorrelationTests
         var norm = new SimpleLogNormalizer();
         var result = norm.Normalize(events);
         var e = Assert.Single(result);
-        e.Timestamp.Kind.Should().Be(DateTimeKind.Utc);
-        e.Source.Should().Be("FW");
-        e.Attributes.Should().ContainKey("ip");
+        Assert.Equal(DateTimeKind.Utc, e.Timestamp.Kind);
+        Assert.Equal("FW", e.Source);
+        Assert.Contains("ip", e.Attributes.Keys);
     }
 
     [Fact]
@@ -33,6 +32,6 @@ public class NormalizationAndCorrelationTests
         };
         var engine = new CorrelationEngine();
         var insights = engine.Correlate(events);
-        insights.Groups.Should().Contain(g => g.Key.StartsWith("IP:1.1.1.1"));
+        Assert.Contains(insights.Groups, g => g.Key.StartsWith("IP:1.1.1.1"));
     }
 }

--- a/tests/SecuNik.Core.Tests/ParserTests.cs
+++ b/tests/SecuNik.Core.Tests/ParserTests.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using System.Threading.Tasks;
-using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using SecuNik.Core.Services;
 using Xunit;
@@ -16,9 +15,9 @@ public class ParserTests
         await File.WriteAllTextAsync(path,
             "<Events><Event><System><EventID>1</EventID><TimeCreated SystemTime=\"2024-01-01T00:00:00Z\"/></System><EventData><Data>Test</Data></EventData></Event></Events>");
         var parser = new WindowsEventLogParser(new NullLogger<WindowsEventLogParser>());
-        (await parser.CanParseAsync(path)).Should().BeTrue();
+        Assert.True(await parser.CanParseAsync(path));
         var findings = await parser.ParseAsync(path);
-        findings.SecurityEvents.Should().NotBeEmpty();
+        Assert.NotEmpty(findings.SecurityEvents);
         File.Delete(path);
     }
 
@@ -28,9 +27,9 @@ public class ParserTests
         var path = Path.GetTempFileName() + ".wtmp";
         await File.WriteAllTextAsync(path, "user pts/0 192.168.0.1 Fri May 1 10:00 still logged in\n");
         var parser = new LinuxSessionLogParser(new NullLogger<LinuxSessionLogParser>());
-        (await parser.CanParseAsync(path)).Should().BeTrue();
+        Assert.True(await parser.CanParseAsync(path));
         var findings = await parser.ParseAsync(path);
-        findings.SecurityEvents.Should().NotBeEmpty();
+        Assert.NotEmpty(findings.SecurityEvents);
         File.Delete(path);
     }
 
@@ -40,9 +39,9 @@ public class ParserTests
         var path = Path.GetTempFileName() + ".log";
         await File.WriteAllTextAsync(path, "127.0.0.1 - - [10/Oct/2000:13:55:36 -0700] \"GET /index.html HTTP/1.0\" 200 2326\n");
         var parser = new WebServerLogParser(new NullLogger<WebServerLogParser>());
-        (await parser.CanParseAsync(path)).Should().BeTrue();
+        Assert.True(await parser.CanParseAsync(path));
         var findings = await parser.ParseAsync(path);
-        findings.SecurityEvents.Should().NotBeEmpty();
+        Assert.NotEmpty(findings.SecurityEvents);
         File.Delete(path);
     }
 
@@ -52,9 +51,9 @@ public class ParserTests
         var path = Path.GetTempFileName() + ".pcap";
         await File.WriteAllBytesAsync(path, new byte[] {0x00,0x01,0x02});
         var parser = new NetworkCaptureParser(new NullLogger<NetworkCaptureParser>());
-        (await parser.CanParseAsync(path)).Should().BeTrue();
+        Assert.True(await parser.CanParseAsync(path));
         var findings = await parser.ParseAsync(path);
-        findings.SecurityEvents.Should().NotBeEmpty();
+        Assert.NotEmpty(findings.SecurityEvents);
         File.Delete(path);
     }
 
@@ -64,9 +63,9 @@ public class ParserTests
         var path = Path.GetTempFileName() + ".syslog";
         await File.WriteAllTextAsync(path, "Jan 10 12:00:00 localhost sshd: Accepted password for user from 1.2.3.4 port 22 ssh2\n");
         var parser = new SyslogParser(new NullLogger<SyslogParser>());
-        (await parser.CanParseAsync(path)).Should().BeTrue();
+        Assert.True(await parser.CanParseAsync(path));
         var findings = await parser.ParseAsync(path);
-        findings.SecurityEvents.Should().NotBeEmpty();
+        Assert.NotEmpty(findings.SecurityEvents);
         File.Delete(path);
     }
 
@@ -76,9 +75,9 @@ public class ParserTests
         var path = Path.GetTempFileName() + ".fwlog";
         await File.WriteAllTextAsync(path, "DROP IN=eth0 SRC=1.1.1.1 DST=2.2.2.2\n");
         var parser = new FirewallLogParser(new NullLogger<FirewallLogParser>());
-        (await parser.CanParseAsync(path)).Should().BeTrue();
+        Assert.True(await parser.CanParseAsync(path));
         var findings = await parser.ParseAsync(path);
-        findings.SecurityEvents.Should().NotBeEmpty();
+        Assert.NotEmpty(findings.SecurityEvents);
         File.Delete(path);
     }
 
@@ -88,9 +87,9 @@ public class ParserTests
         var path = Path.GetTempFileName() + ".dblog";
         await File.WriteAllTextAsync(path, "2025-06-10T12:00:00Z [ERROR] database crashed\n");
         var parser = new DatabaseLogParser(new NullLogger<DatabaseLogParser>());
-        (await parser.CanParseAsync(path)).Should().BeTrue();
+        Assert.True(await parser.CanParseAsync(path));
         var findings = await parser.ParseAsync(path);
-        findings.SecurityEvents.Should().NotBeEmpty();
+        Assert.NotEmpty(findings.SecurityEvents);
         File.Delete(path);
     }
 
@@ -100,9 +99,9 @@ public class ParserTests
         var path = Path.GetTempFileName() + ".maillog";
         await File.WriteAllTextAsync(path, "Jan 10 12:00:00 mail postfix/smtpd[1234]: connect from 1.2.3.4\n");
         var parser = new MailServerLogParser(new NullLogger<MailServerLogParser>());
-        (await parser.CanParseAsync(path)).Should().BeTrue();
+        Assert.True(await parser.CanParseAsync(path));
         var findings = await parser.ParseAsync(path);
-        findings.SecurityEvents.Should().NotBeEmpty();
+        Assert.NotEmpty(findings.SecurityEvents);
         File.Delete(path);
     }
 
@@ -112,9 +111,9 @@ public class ParserTests
         var path = Path.GetTempFileName() + ".dnslog";
         await File.WriteAllTextAsync(path, "10-Jun-2025 12:00:00.000 client 1.1.1.1#12345: query: example.com IN A +\n");
         var parser = new DnsLogParser(new NullLogger<DnsLogParser>());
-        (await parser.CanParseAsync(path)).Should().BeTrue();
+        Assert.True(await parser.CanParseAsync(path));
         var findings = await parser.ParseAsync(path);
-        findings.SecurityEvents.Should().NotBeEmpty();
+        Assert.NotEmpty(findings.SecurityEvents);
         File.Delete(path);
     }
 }

--- a/tests/SecuNik.Core.Tests/SecuNik.Core.Tests.csproj
+++ b/tests/SecuNik.Core.Tests/SecuNik.Core.Tests.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="FluentAssertions" Version="8.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.5.3" />


### PR DESCRIPTION
## Summary
- replace FluentAssertions usage with built-in `Assert`
- drop FluentAssertions NuGet dependency
- document assertion switch in README

## Testing
- `dotnet test tests/SecuNik.Core.Tests/SecuNik.Core.Tests.csproj`
- `dotnet test tests/SecuNik.API.Tests/SecuNik.API.Tests.csproj`
- `dotnet test tests/SecuNik.AI.Tests/SecuNik.AI.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_684934b361448323a3ca894c2546d2ad