### PR TITLE
Fix error handling variable scope in app.js

### DIFF
--- a/src/SecuNik.API/wwwroot/js/app.js
+++ b/src/SecuNik.API/wwwroot/js/app.js
@@ -1284,8 +1284,9 @@ class SecuNikDashboard {
 
             if (!response.ok) {
                 let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+                let errorData;
                 try {
-                    const errorData = await response.text();
+                    errorData = await response.text();
                     const jsonError = JSON.parse(errorData);
                     errorMessage = jsonError.error || jsonError.message || errorMessage;
                 } catch (e) {


### PR DESCRIPTION
## Summary
- ensure `errorData` is declared outside the `try` block for proper scope

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684be66537c88323a1785af1c7a55d5a