### PR TITLE
Fix shareAnalysis summary retrieval

### DIFF
--- a/src/SecuNik.API/wwwroot/js/app.js
+++ b/src/SecuNik.API/wwwroot/js/app.js
@@ -628,12 +628,15 @@ class SecuNikDashboard {
 
         try {
             // Create shareable summary
+            const result = this.state.currentAnalysis.result || {};
+            const executive = result.executive || result.Executive || {};
+
             const shareData = {
                 analysisId: this.state.currentAnalysis.analysisId,
                 fileName: this.state.currentFile.name,
                 timestamp: this.state.currentAnalysis.timestamp,
-                riskScore: this.calculateRiskScore(this.state.currentAnalysis.result),
-                summary: this.state.currentAnalysis.result.executiveSummary?.summary || 'Analysis completed'
+                riskScore: this.calculateRiskScore(result),
+                summary: executive.summary || 'Analysis completed'
             };
 
             if (navigator.share) {


### PR DESCRIPTION
## Summary
- fix `shareAnalysis` to use `result.executive` or `result.Executive`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d3d98760c83239f0d9f3cce65892c