### PR TITLE
Remove replacement header comments

### DIFF
--- a/src/SecuNik.Core/Exceptions/SecuNikException.cs
+++ b/src/SecuNik.Core/Exceptions/SecuNikException.cs
@@ -1,6 +1,4 @@
-// File: src\SecuNik.Core\Exceptions\SecuNikException.cs
 using System;
-
 namespace SecuNik.Core.Exceptions
 {
     /// <summary>

--- a/src/SecuNik.Core/Models/AnalysisResult.cs
+++ b/src/SecuNik.Core/Models/AnalysisResult.cs
@@ -1,7 +1,5 @@
-// File: src\SecuNik.Core\Models\AnalysisResult.cs
 using System;
 using System.Collections.Generic;
-
 namespace SecuNik.Core.Models
 {
     /// <summary>

--- a/src/SecuNik.Core/Models/ParsingModels.cs
+++ b/src/SecuNik.Core/Models/ParsingModels.cs
@@ -1,6 +1,4 @@
-// File: src\SecuNik.Core\Models\ParsingModels.cs
 using System.Collections.Generic;
-
 namespace SecuNik.Core.Models
 {
     /// <summary>

--- a/src/SecuNik.Core/Services/CsvLogParser.cs
+++ b/src/SecuNik.Core/Services/CsvLogParser.cs
@@ -1,6 +1,3 @@
-// Replace your CsvLogParser.cs with this updated version
-// File: src/SecuNik.Core/Services/CsvLogParser.cs
-
 using SecuNik.Core.Interfaces;
 using SecuNik.Core.Models;
 using SecuNik.Core.Exceptions;


### PR DESCRIPTION
## Summary
- drop leftover header comments that advised replacing old files
- keep class summaries untouched

## Testing
- `dotnet restore src/SecuNik.sln`
- `dotnet build src/SecuNik.sln --no-restore -warnaserror` *(fails: missing packages and CS errors)*

------
https://chatgpt.com/codex/tasks/task_e_684d3d9971188323aa07f6b9cf0bd0ee