### PR TITLE
Fix fallback AI service

### DIFF
--- a/src/SecuNik.AI/Configuration/ServiceCollectionExtensions.cs
+++ b/src/SecuNik.AI/Configuration/ServiceCollectionExtensions.cs
@@ -42,7 +42,7 @@ namespace SecuNik.AI.Configuration
                 }
 
                 // Fallback to rule-based service
-                return new OpenAIAnalysisService(provider.GetRequiredService<ILogger<OpenAIAnalysisService>>());
+                return new SecurityAnalysisService(provider.GetRequiredService<ILogger<SecurityAnalysisService>>());
             });
 
             return services;

--- a/tests/SecuNik.AI.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/SecuNik.AI.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using SecuNik.AI.Configuration;
+using SecuNik.AI.Services;
+using SecuNik.Core.Interfaces;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace SecuNik.AI.Tests;
+
+public class ServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddSecuNikAI_NoApiKey_ResolvesSecurityAnalysisService()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>())
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddLogging();
+        services.AddSecuNikAI();
+
+        using var provider = services.BuildServiceProvider();
+        var service = provider.GetRequiredService<IAIAnalysisService>();
+
+        Assert.IsType<SecurityAnalysisService>(service);
+    }
+}


### PR DESCRIPTION
## Summary
- return `SecurityAnalysisService` when OpenAI isn't configured
- log using `ILogger<SecurityAnalysisService>`
- add a unit test ensuring the fallback resolves `SecurityAnalysisService`

## Testing
- `dotnet test tests/SecuNik.AI.Tests/SecuNik.AI.Tests.csproj -v minimal` *(fails: duplicate model definitions)*

------
https://chatgpt.com/codex/tasks/task_e_684e2e6948cc8323955fdc49c046783a