### PR TITLE
Add Recommendations Tab

### DIFF
--- a/src/SecuNik.API/wwwroot/css/recommendations.css
+++ b/src/SecuNik.API/wwwroot/css/recommendations.css
@@ -1,1 +1,31 @@
 /* Styles for recommendations tab */
+.recommendations-container {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+    padding: var(--space-lg);
+}
+
+.recommended-actions {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+}
+
+.recommended-actions li {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-sm);
+    background: var(--bg-card);
+    border: 1px solid var(--border-tertiary);
+    border-radius: var(--radius-sm);
+    padding: var(--space-md);
+}
+
+.action-number {
+    font-weight: 600;
+    color: var(--text-accent);
+}

--- a/src/SecuNik.API/wwwroot/index.html
+++ b/src/SecuNik.API/wwwroot/index.html
@@ -520,6 +520,20 @@
                     </section>
 
                     <!-- Other tabs remain the same but add them as needed -->
+                    <!-- Recommendations Tab -->
+                    <section class="tab-section" id="recommendationsTab" role="tabpanel" aria-labelledby="recommendations-tab">
+                        <div class="section-header">
+                            <h2><i data-feather="zap" aria-hidden="true"></i> Recommendations</h2>
+                        </div>
+                        <div class="section-content">
+                            <div id="recommendationsContainer" class="recommendations-container">
+                                <div class="placeholder-content">
+                                    <i data-feather="zap" width="32" height="32" aria-hidden="true"></i>
+                                    <p>Recommended actions will appear here after analysis</p>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
                     <!-- Case Management Tab -->
                     <section class="tab-section" id="caseTab" role="tabpanel" aria-labelledby="case-tab">
                         <div class="section-header">

--- a/src/SecuNik.API/wwwroot/js/tabs/recommendations.js
+++ b/src/SecuNik.API/wwwroot/js/tabs/recommendations.js
@@ -1,0 +1,46 @@
+export function initTab(analysis) {
+    if (!analysis) return;
+    render(analysis);
+}
+
+export function render(analysis) {
+    if (!analysis) return;
+
+    const container = document.getElementById('recommendationsContainer') ||
+        document.querySelector('.recommendations-container');
+
+    if (!container) return;
+
+    let actions = analysis.result?.ai?.recommendedActions || [];
+    if (!Array.isArray(actions)) {
+        actions = actions ? [actions] : [];
+    }
+
+    if (actions.length === 0) {
+        container.innerHTML = `
+            <div class="placeholder-content">
+                <i data-feather="zap" width="32" height="32"></i>
+                <p>No recommendations available</p>
+            </div>
+        `;
+    } else {
+        container.innerHTML = `
+            <ul class="recommended-actions">
+                ${actions.map((a, idx) => `
+                    <li><span class="action-number">${idx + 1}.</span> <span class="action-text">${escapeHTML(a)}</span></li>
+                `).join('')}
+            </ul>
+        `;
+    }
+
+    if (typeof feather !== 'undefined') {
+        feather.replace();
+    }
+}
+
+function escapeHTML(str) {
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}


### PR DESCRIPTION
## Summary
- implement recommendations tab logic with init and render functions
- style recommendations tab content
- add Recommendations tab section to HTML

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e2e6eba188323bba79c0cfc29d16a