### PR TITLE
Set SecurityEvent priority from severity

### DIFF
--- a/src/SecuNik.Core/Models/SecurityEvent.cs
+++ b/src/SecuNik.Core/Models/SecurityEvent.cs
@@ -49,6 +49,21 @@ public class SecurityEvent
 
     /// <summary>Confidence score assigned by analysis engines.</summary>
     public double ConfidenceScore { get; set; }
+
+    /// <summary>
+    /// Helper to map textual severity values to a priority level.
+    /// </summary>
+    public static SecurityEventPriority GetPriorityFromSeverity(string? severity)
+    {
+        return severity?.Trim().ToLower() switch
+        {
+            "critical" or "4" => SecurityEventPriority.Critical,
+            "high" or "3" => SecurityEventPriority.High,
+            "medium" or "2" => SecurityEventPriority.Medium,
+            "low" or "info" or "informational" or "1" or "0" => SecurityEventPriority.Low,
+            _ => SecurityEventPriority.Medium
+        };
+    }
 }
 
 /// <summary>

--- a/src/SecuNik.Core/Services/CsvLogParser.cs
+++ b/src/SecuNik.Core/Services/CsvLogParser.cs
@@ -189,12 +189,14 @@ namespace SecuNik.Core.Services
 
         private SecurityEvent CreateSecurityEventFromRecord(IDictionary<string, object> record)
         {
+            var severity = ExtractSeverity(record);
             var secEvent = new SecurityEvent
             {
                 Timestamp = ExtractTimestamp(record),
                 EventType = ExtractEventType(record),
                 Description = ExtractDescription(record),
-                Severity = ExtractSeverity(record),
+                Severity = severity,
+                Priority = SecurityEvent.GetPriorityFromSeverity(severity),
                 Attributes = record.ToDictionary(kvp => kvp.Key, kvp => kvp.Value?.ToString() ?? "")
             };
 
@@ -203,12 +205,14 @@ namespace SecuNik.Core.Services
 
         private SecurityEvent CreateSecurityEventFromLine(string line, int lineNumber)
         {
+            var severity = ExtractSeverityFromLine(line);
             var secEvent = new SecurityEvent
             {
                 Timestamp = ExtractTimestampFromLine(line),
                 EventType = "Log Entry",
                 Description = line.Length > 200 ? line.Substring(0, 200) + "..." : line,
-                Severity = ExtractSeverityFromLine(line),
+                Severity = severity,
+                Priority = SecurityEvent.GetPriorityFromSeverity(severity),
                 Attributes = new Dictionary<string, string>
                 {
                     ["LineNumber"] = lineNumber.ToString(),

--- a/src/SecuNik.Core/Services/DatabaseLogParser.cs
+++ b/src/SecuNik.Core/Services/DatabaseLogParser.cs
@@ -46,12 +46,14 @@ namespace SecuNik.Core.Services
                 foreach (var line in lines)
                 {
                     if (string.IsNullOrWhiteSpace(line)) continue;
+                    var severity = line.Contains("error", StringComparison.OrdinalIgnoreCase) ? "Medium" : "Low";
                     findings.SecurityEvents.Add(new SecurityEvent
                     {
                         Timestamp = DateTime.Now,
                         EventType = "database",
                         Description = line.Trim(),
-                        Severity = line.Contains("error", StringComparison.OrdinalIgnoreCase) ? "Medium" : "Low"
+                        Severity = severity,
+                        Priority = SecurityEvent.GetPriorityFromSeverity(severity)
                     });
                 }
             }

--- a/src/SecuNik.Core/Services/DnsLogParser.cs
+++ b/src/SecuNik.Core/Services/DnsLogParser.cs
@@ -46,12 +46,14 @@ namespace SecuNik.Core.Services
                 foreach (var line in lines)
                 {
                     if (string.IsNullOrWhiteSpace(line)) continue;
+                    var severity = line.Contains("error", StringComparison.OrdinalIgnoreCase) ? "Medium" : "Low";
                     findings.SecurityEvents.Add(new SecurityEvent
                     {
                         Timestamp = DateTime.Now,
                         EventType = "dns",
                         Description = line.Trim(),
-                        Severity = line.Contains("error", StringComparison.OrdinalIgnoreCase) ? "Medium" : "Low"
+                        Severity = severity,
+                        Priority = SecurityEvent.GetPriorityFromSeverity(severity)
                     });
                 }
             }

--- a/src/SecuNik.Core/Services/FirewallLogParser.cs
+++ b/src/SecuNik.Core/Services/FirewallLogParser.cs
@@ -46,12 +46,14 @@ namespace SecuNik.Core.Services
                 foreach (var line in lines)
                 {
                     if (string.IsNullOrWhiteSpace(line)) continue;
+                    var severity = line.Contains("DROP", StringComparison.OrdinalIgnoreCase) || line.Contains("DENIED", StringComparison.OrdinalIgnoreCase) ? "Medium" : "Low";
                     findings.SecurityEvents.Add(new SecurityEvent
                     {
                         Timestamp = DateTime.Now,
                         EventType = "firewall",
                         Description = line.Trim(),
-                        Severity = line.Contains("DROP", StringComparison.OrdinalIgnoreCase) || line.Contains("DENIED", StringComparison.OrdinalIgnoreCase) ? "Medium" : "Low"
+                        Severity = severity,
+                        Priority = SecurityEvent.GetPriorityFromSeverity(severity)
                     });
                 }
             }

--- a/src/SecuNik.Core/Services/LinuxSessionLogParser.cs
+++ b/src/SecuNik.Core/Services/LinuxSessionLogParser.cs
@@ -46,12 +46,14 @@ namespace SecuNik.Core.Services
                 foreach (var line in lines)
                 {
                     if (string.IsNullOrWhiteSpace(line)) continue;
+                    const string severity = "Low";
                     findings.SecurityEvents.Add(new SecurityEvent
                     {
                         Timestamp = DateTime.Now,
                         EventType = "session",
                         Description = line.Trim(),
-                        Severity = "Low"
+                        Severity = severity,
+                        Priority = SecurityEvent.GetPriorityFromSeverity(severity)
                     });
                 }
             }

--- a/src/SecuNik.Core/Services/MailServerLogParser.cs
+++ b/src/SecuNik.Core/Services/MailServerLogParser.cs
@@ -46,12 +46,14 @@ namespace SecuNik.Core.Services
                 foreach (var line in lines)
                 {
                     if (string.IsNullOrWhiteSpace(line)) continue;
+                    var severity = line.Contains("error", StringComparison.OrdinalIgnoreCase) ? "Medium" : "Low";
                     findings.SecurityEvents.Add(new SecurityEvent
                     {
                         Timestamp = DateTime.Now,
                         EventType = "mail",
                         Description = line.Trim(),
-                        Severity = line.Contains("error", StringComparison.OrdinalIgnoreCase) ? "Medium" : "Low"
+                        Severity = severity,
+                        Priority = SecurityEvent.GetPriorityFromSeverity(severity)
                     });
                 }
             }

--- a/src/SecuNik.Core/Services/NetworkCaptureParser.cs
+++ b/src/SecuNik.Core/Services/NetworkCaptureParser.cs
@@ -43,12 +43,14 @@ namespace SecuNik.Core.Services
             try
             {
                 // Placeholder: just report that a capture file was processed
+                const string severity = "Low";
                 findings.SecurityEvents.Add(new SecurityEvent
                 {
                     Timestamp = DateTime.Now,
                     EventType = "pcap",
                     Description = "Network capture processed",
-                    Severity = "Low"
+                    Severity = severity,
+                    Priority = SecurityEvent.GetPriorityFromSeverity(severity)
                 });
             }
             catch (Exception ex)

--- a/src/SecuNik.Core/Services/SyslogParser.cs
+++ b/src/SecuNik.Core/Services/SyslogParser.cs
@@ -50,12 +50,14 @@ namespace SecuNik.Core.Services
                     var m = SyslogRegex.Match(line);
                     if (!m.Success) continue;
                     DateTime.TryParse($"{m.Groups["month"].Value} {m.Groups["day"].Value} {DateTime.Now.Year} {m.Groups["time"].Value}", out var ts);
+                    const string severity = "Low";
                     findings.SecurityEvents.Add(new SecurityEvent
                     {
                         Timestamp = ts,
                         EventType = m.Groups["service"].Value,
                         Description = m.Groups["msg"].Value,
-                        Severity = "Low"
+                        Severity = severity,
+                        Priority = SecurityEvent.GetPriorityFromSeverity(severity)
                     });
                 }
             }

--- a/src/SecuNik.Core/Services/WebServerLogParser.cs
+++ b/src/SecuNik.Core/Services/WebServerLogParser.cs
@@ -52,12 +52,14 @@ namespace SecuNik.Core.Services
                     if (!match.Success) continue;
                     DateTime.TryParse(match.Groups["time"].Value.Split(' ')[0], out var ts);
                     var ip = match.Groups["ip"].Value;
+                    const string severity = "Low";
                     findings.SecurityEvents.Add(new SecurityEvent
                     {
                         Timestamp = ts,
                         EventType = "http",
                         Description = line.Trim(),
-                        Severity = "Low",
+                        Severity = severity,
+                        Priority = SecurityEvent.GetPriorityFromSeverity(severity),
                         Attributes = new Dictionary<string, string>
                         {
                             ["ip"] = ip,


### PR DESCRIPTION
## Summary
- map severity strings to `SecurityEventPriority`
- propagate priority into events created by parsers
- verify that WindowsEventLogParser sets priority correctly

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e3fa37dd88323ab6c4879df5050d9