### PR TITLE
Update forensic key finding selection

### DIFF
--- a/src/SecuNik.API/Program.cs
+++ b/src/SecuNik.API/Program.cs
@@ -475,10 +475,17 @@ namespace SecuNik.API
                 AnalysisTimestamp = DateTime.UtcNow,
                 EvidenceIntegrity = "Verified",
                 ChainOfCustody = new List<string> { "SecuNik Analysis Engine" },
-                KeyFindings = findings.SecurityEvents.Where(e => e.Priority >= SecurityEventPriority.High)
-                                                   .Select(e => e.Message)
-                                                   .Take(10)
-                                                   .ToList(),
+                // Select key findings based on either numerical priority or textual severity.
+                // Events labeled as "High" or "Critical" severity are included
+                // even when their Priority field remains lower.
+                KeyFindings = findings.SecurityEvents
+                                       .Where(e =>
+                                           e.Priority >= SecurityEventPriority.High ||
+                                           string.Equals(e.Severity, "High", StringComparison.OrdinalIgnoreCase) ||
+                                           string.Equals(e.Severity, "Critical", StringComparison.OrdinalIgnoreCase))
+                                       .Select(e => e.Message)
+                                       .Take(10)
+                                       .ToList(),
                 ArtifactCount = findings.DetectedIOCs.Count + findings.SecurityEvents.Count,
                 RecommendedActions = new List<string>
                 {


### PR DESCRIPTION
## Summary
- include "High" and "Critical" severity events in forensic analysis key findings
- document the new logic

## Testing
- `dotnet build src/SecuNik.sln --no-restore --verbosity minimal`
- `dotnet test tests/SecuNik.API.Tests/SecuNik.API.Tests.csproj --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_684e3fa8c4c4832383caa16e0287d05b