### PR TITLE
Implement Threat Intel tab data loading

### DIFF
--- a/src/SecuNik.API/wwwroot/js/app.js
+++ b/src/SecuNik.API/wwwroot/js/app.js
@@ -19,7 +19,7 @@ import { initTab as initHelpTab } from "./tabs/help.js";
 import { exportIOCs, init as initIocsTab } from "./tabs/iocs.js";
 import { initTab as initRecommendationsTab } from "./tabs/recommendations.js";
 import { initTab as initSettingsTab } from "./tabs/settings.js";
-import { initTab as initThreatIntelTab } from "./tabs/threatIntel.js";
+import { initTab as initThreatIntelTab, render as renderThreatIntelTab, fetchThreatIntel } from "./tabs/threatIntel.js";
 import { init as initTimelineTab, render as renderTimelineTab } from "./tabs/timeline.js";
 
 class SecuNikDashboard {
@@ -576,6 +576,9 @@ class SecuNikDashboard {
             renderEventsTab(analysis);
             renderTimelineTab(analysis);
             renderCaseManagementTab();
+
+            const threatData = await fetchThreatIntel();
+            renderThreatIntelTab(threatData);
         } catch (error) {
             console.error('Error updating tabs:', error);
         }

--- a/src/SecuNik.API/wwwroot/js/services/api.js
+++ b/src/SecuNik.API/wwwroot/js/services/api.js
@@ -7,7 +7,8 @@ class SecuNikAPI {
             analyzePath: '/api/analysis/analyze-path',
             supportedTypes: '/api/analysis/supported-types',
             health: '/api/analysis/health',
-            canProcess: '/api/analysis/can-process'
+            canProcess: '/api/analysis/can-process',
+            threatIntelLatest: '/api/threatintel/latest'
         };
         this.defaultHeaders = {
             'Accept': 'application/json'
@@ -143,6 +144,25 @@ class SecuNikAPI {
         } catch (error) {
             console.error('Can process file error:', error);
             return false;
+        }
+    }
+
+    // Retrieve latest threat intelligence
+    async getLatestThreatIntel() {
+        try {
+            const response = await fetch(this.baseURL + this.endpoints.threatIntelLatest, {
+                method: 'GET',
+                headers: this.defaultHeaders
+            });
+
+            if (!response.ok) {
+                throw new Error(`Failed to get threat intel: ${response.status} ${response.statusText}`);
+            }
+
+            return await response.json();
+        } catch (error) {
+            console.error('Threat intel fetch error:', error);
+            throw error;
         }
     }
 
@@ -590,4 +610,9 @@ export async function checkHealth(endpoints) {
     const api = new SecuNikAPI();
     const health = await api.checkHealth();
     return health.isHealthy;
+}
+
+export async function getLatestThreatIntel() {
+    const api = new SecuNikAPI();
+    return await api.getLatestThreatIntel();
 }

--- a/src/SecuNik.API/wwwroot/js/tabs/threatIntel.js
+++ b/src/SecuNik.API/wwwroot/js/tabs/threatIntel.js
@@ -1,4 +1,83 @@
-export function initTab(analysis) {
-    // initialize threatIntel tab
+import * as api from '../services/api.js';
+
+// Initialize the Threat Intelligence tab. Currently there are no controls to
+// set up so this simply acts as a placeholder should future functionality be
+// required.
+export function initTab() {
+    return;
+}
+
+// Retrieve the latest threat intelligence data from the backend API.
+export async function fetchThreatIntel() {
+    try {
+        const data = await api.getLatestThreatIntel();
+        return Array.isArray(data) ? data : [];
+    } catch (err) {
+        console.error('Failed to fetch threat intelligence:', err);
+        return [];
+    }
+}
+
+// Render threat indicators in the Threat Intelligence tab.
+export function render(indicators = []) {
+    const container = document.getElementById('threatIntelContainer') ||
+        document.querySelector('.threat-intel-container');
+    if (!container) return;
+
+    if (!Array.isArray(indicators) || indicators.length === 0) {
+        container.innerHTML = `
+            <div class="placeholder-content">
+                <i data-feather="alert-circle" width="32" height="32"></i>
+                <p>No threat intelligence available</p>
+            </div>`;
+        if (typeof feather !== 'undefined') {
+            feather.replace();
+        }
+        return;
+    }
+
+    container.innerHTML = `
+        <table class="threat-intel-table">
+            <thead>
+                <tr>
+                    <th>Type</th>
+                    <th>Value</th>
+                    <th>Description</th>
+                    <th>Last Seen</th>
+                    <th>Source</th>
+                </tr>
+            </thead>
+            <tbody>
+                ${indicators.map(i => `
+                    <tr>
+                        <td>${escapeHTML(i.type)}</td>
+                        <td>${escapeHTML(i.value)}</td>
+                        <td>${escapeHTML(i.description)}</td>
+                        <td>${formatDate(i.lastSeen)}</td>
+                        <td>${escapeHTML(i.source)}</td>
+                    </tr>
+                `).join('')}
+            </tbody>
+        </table>`;
+
+    if (typeof feather !== 'undefined') {
+        feather.replace();
+    }
+}
+
+function escapeHTML(str) {
+    return String(str || '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
+function formatDate(date) {
+    if (!date) return 'Unknown';
+    try {
+        return new Date(date).toLocaleString();
+    } catch {
+        return 'Unknown';
+    }
 }
 


### PR DESCRIPTION
## Summary
- fetch threat intel from the API service
- provide API helpers to query `/api/threatintel/latest`
- render threat indicators in the new Threat Intelligence tab
- load and render threat intel when updating tabs

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e44aff78c832395af243a7a36ae1f