### PR TITLE
Fix frontend API base URL detection

### DIFF
--- a/src/SecuNik.API/wwwroot/js/services/api.js
+++ b/src/SecuNik.API/wwwroot/js/services/api.js
@@ -5,7 +5,15 @@
 
 class SecuNikAPI {
     constructor() {
-        this.baseURL = window.location.origin;
+        // Determine API base URL. If the dashboard is opened directly from the
+        // filesystem, window.location.origin will be "null" and API calls will
+        // fail. Default to the local development server in that case.
+        const origin = window.location.origin;
+        if (!origin || origin === 'null' || origin.startsWith('file://')) {
+            this.baseURL = 'http://localhost:5043';
+        } else {
+            this.baseURL = origin;
+        }
         this.endpoints = {
             upload: '/api/analysis/upload',
             analyzePath: '/api/analysis/analyze-path',


### PR DESCRIPTION
## Summary
- fall back to `http://localhost:5043` in `api.js` if the page is opened from `file://`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e7089c34c83239c4f8d56f15d0e23