### PR TITLE
Update settings tab init and dashboard refresh

### DIFF
--- a/src/SecuNik.API/wwwroot/js/app.js
+++ b/src/SecuNik.API/wwwroot/js/app.js
@@ -812,6 +812,22 @@ class SecuNikDashboard {
     }
 
     /**
+     * Refresh dashboard content
+     */
+    async refreshDashboard() {
+        if (!this.state.currentAnalysis) return;
+
+        try {
+            const dashboardModule = await import('./tabs/dashboard.js');
+            if (dashboardModule.initTab) {
+                dashboardModule.initTab(this.state.currentAnalysis);
+            }
+        } catch (error) {
+            console.error('Failed to refresh dashboard:', error);
+        }
+    }
+
+    /**
      * Initialize animations
      */
     initializeAnimations() {

--- a/src/SecuNik.API/wwwroot/js/tabs/settings.js
+++ b/src/SecuNik.API/wwwroot/js/tabs/settings.js
@@ -1,4 +1,4 @@
-export function initTab(analysis) {
+export function init(analysis) {
     setupSettingsForm();
     loadUserSettings();
     setupEventListeners();
@@ -446,7 +446,7 @@ export function render() {
     `;
 
     // Re-initialize after rendering
-    initTab();
+    init();
     feather.replace();
 }
 


### PR DESCRIPTION
## Summary
- rename `initTab` to `init` in `settings.js`
- update call sites after rename
- add `refreshDashboard()` helper in app.js

## Testing
- `dotnet test tests/SecuNik.API.Tests/SecuNik.API.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684e7b708a4c83238749f1a94b88af7a